### PR TITLE
[FIX] project_scrum: allow to use portal link

### DIFF
--- a/project_scrum/models/project_task.py
+++ b/project_scrum/models/project_task.py
@@ -123,7 +123,7 @@ class ProjectTask(models.Model):
             return [], None
 
     @api.multi
-    def get_formview_id(self):
+    def get_formview_id(self, access_uid=None):
         if all(self.mapped('use_scrum')):
             return self.env.ref('project_scrum.view_ps_sprint_task_form2').id
-        return super().get_formview_id()
+        return super().get_formview_id(access_uid)


### PR DESCRIPTION
This MR fixes the following issue:

Steps to reproduce:
--

- Send any email with odoo with link to any type of document
- Click the link to see the portal of the document.

Expecter behavior:
--

- See the document in portal or odoo.

Current behavior:

- Show internal server error.
- Show the following log.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/werkzeug/serving.py", line 205, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python3.6/dist-packages/werkzeug/serving.py", line 193, in execute
    application_iter = app(environ, start_response)
  File "/home/odoo/instance/odoo/odoo/service/wsgi_server.py", line 140, in application
    return ProxyFix(application_unproxied)(environ, start_response)
  File "/usr/local/lib/python3.6/dist-packages/werkzeug/contrib/fixers.py", line 152, in __call__
    return self.app(environ, start_response)
  File "/home/odoo/instance/odoo/odoo/service/wsgi_server.py", line 117, in application_unproxied
    result = odoo.http.root(environ, start_response)
  File "/home/odoo/instance/odoo/odoo/http.py", line 1320, in __call__
    return self.dispatch(environ, start_response)
  File "/home/odoo/instance/odoo/odoo/http.py", line 1293, in __call__
    return self.app(environ, start_wrapped)
  File "/usr/local/lib/python3.6/dist-packages/werkzeug/wsgi.py", line 599, in __call__
    return self.app(environ, start_response)
  File "/home/odoo/instance/odoo/odoo/http.py", line 1488, in dispatch
    result = ir_http._dispatch()
  File "/home/odoo/instance/odoo/addons/auth_signup/models/ir_http.py", line 19, in _dispatch
    return super(Http, cls)._dispatch()
  File "/home/odoo/instance/odoo/addons/web_editor/models/ir_http.py", line 22, in _dispatch
    return super(IrHttp, cls)._dispatch()
  File "/home/odoo/instance/odoo/addons/http_routing/models/ir_http.py", line 403, in _dispatch
    result = super(IrHttp, cls)._dispatch()
  File "/home/odoo/instance/odoo/addons/utm/models/ir_http.py", line 26, in _dispatch
    response = super(IrHttp, cls)._dispatch()
  File "/home/odoo/instance/odoo/odoo/addons/base/models/ir_http.py", line 212, in _dispatch
    return cls._handle_exception(e)
  File "/home/odoo/instance/odoo/addons/website/models/ir_http.py", line 195, in _handle_exception
    return super(Http, cls)._handle_exception(exception)
  File "/home/odoo/instance/odoo/addons/utm/models/ir_http.py", line 31, in _handle_exception
    response = super(IrHttp, cls)._handle_exception(exc)
  File "/home/odoo/instance/odoo/odoo/addons/base/models/ir_http.py", line 182, in _handle_exception
    return request._handle_exception(exception)
  File "/home/odoo/instance/odoo/odoo/http.py", line 776, in _handle_exception
    return super(HttpRequest, self)._handle_exception(exception)
  File "/home/odoo/instance/odoo/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/home/odoo/instance/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/home/odoo/instance/odoo/odoo/addons/base/models/ir_http.py", line 208, in _dispatch
    result = request.dispatch()
  File "/home/odoo/instance/odoo/odoo/http.py", line 835, in dispatch
    r = self._call_function(**self.params)
  File "/home/odoo/instance/odoo/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/odoo/instance/odoo/odoo/service/model.py", line 98, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/odoo/instance/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/odoo/instance/odoo/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/home/odoo/instance/odoo/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/instance/odoo/addons/mail/controllers/main.py", line 185, in mail_action_view
    return self._redirect_to_record(model, res_id, access_token, **kwargs)
  File "/home/odoo/instance/odoo/addons/portal/controllers/mail.py", line 174, in _redirect_to_record
    return super(MailController, cls)._redirect_to_record(model, res_id, access_token=access_token)
  File "/home/odoo/instance/odoo/addons/mail/controllers/main.py", line 77, in _redirect_to_record
    record_action = record_sudo.get_access_action(access_uid=uid)
  File "/home/odoo/instance/odoo/addons/portal/models/portal_mixin.py", line 137, in get_access_action
    return super(PortalMixin, self).get_access_action(access_uid)
  File "/home/odoo/instance/odoo/odoo/models.py", line 1549, in get_access_action
    return self[0].get_formview_action(access_uid=access_uid)
  File "/home/odoo/instance/odoo/odoo/models.py", line 1528, in get_formview_action
    view_id = self.sudo().get_formview_id(access_uid=access_uid)
```